### PR TITLE
UNOWIFIDEVED setup pin 4 HIGH [canceled]

### DIFF
--- a/ArduinoFirmwareEsp/ArduinoFirmwareEsp.ino
+++ b/ArduinoFirmwareEsp/ArduinoFirmwareEsp.ino
@@ -20,6 +20,11 @@ ESP8266WebServer server(80);    //server UI
 
 void setup() {
 
+#if defined(UNOWIFIDEVED)
+  pinMode(4, OUTPUT);
+  digitalWrite(4, 1);
+#endif
+  
   pinMode(WIFI_LED, OUTPUT);      //initialize wifi LED
   digitalWrite(WIFI_LED, LOW);
   ArduinoOTA.begin();             //OTA ESP


### PR DESCRIPTION
> [<img alt="jandrassy" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/jandrassy) **Authored by [jandrassy](https://github.com/jandrassy)**
_<time datetime="2017-09-08T04:26:33Z" title="Friday, September 8th 2017, 6:26:33 am +02:00">Sep 8, 2017</time>_
_Closed <time datetime="2017-10-24T11:45:12Z" title="Tuesday, October 24th 2017, 1:45:12 pm +02:00">Oct 24, 2017</time>_
---

it is necessary in setup() to set pin 4 high for UNOWIFIDEVED for Atmel <-> ESP communication over SC16IS750. Sometimes the pin doesn't float high enough.